### PR TITLE
[Refactor] 인증 정보 송수신 모델 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     // kafka
     implementation 'org.springframework.kafka:spring-kafka'
     implementation 'io.projectreactor.kafka:reactor-kafka'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis-reactive'
     testImplementation 'org.springframework.kafka:spring-kafka-test'
 
     annotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     implementation 'org.springframework.kafka:spring-kafka'
     implementation 'io.projectreactor.kafka:reactor-kafka'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis-reactive'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     testImplementation 'org.springframework.kafka:spring-kafka-test'
 
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/example/chatgateway/domain/dto/TokenDTO.java
+++ b/src/main/java/com/example/chatgateway/domain/dto/TokenDTO.java
@@ -12,6 +12,6 @@ import java.util.UUID;
 @AllArgsConstructor
 @NoArgsConstructor
 public class TokenDTO {
-    private UUID id;
+    private String id;
     private String token;
 }

--- a/src/main/java/com/example/chatgateway/domain/dto/UserInfoDTO.java
+++ b/src/main/java/com/example/chatgateway/domain/dto/UserInfoDTO.java
@@ -12,7 +12,7 @@ import java.util.UUID;
 @AllArgsConstructor
 @NoArgsConstructor
 public class UserInfoDTO {
-    private UUID id;
+    private String id;
     private String email;
     private String role;
     private String token;

--- a/src/main/java/com/example/chatgateway/global/config/ReactiveRedisConfig.java
+++ b/src/main/java/com/example/chatgateway/global/config/ReactiveRedisConfig.java
@@ -4,22 +4,25 @@ import com.example.chatgateway.domain.dto.UserInfoDTO;
 import io.lettuce.core.ClientOptions;
 import io.lettuce.core.SocketOptions;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration;
+import org.springframework.boot.autoconfigure.data.redis.RedisReactiveAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.core.ReactiveRedisTemplate;
 import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 import java.time.Duration;
 
 @Configuration
-@EnableRedisRepositories
-public class RedisConfig {
+@EnableAutoConfiguration(exclude={RedisAutoConfiguration.class, RedisReactiveAutoConfiguration.class}) // 자동 생성 설정과 커스텀 설정 충돌 방지
+public class ReactiveRedisConfig {
 
     @Value("${spring.data.redis.host}")
     private String host;
@@ -29,7 +32,8 @@ public class RedisConfig {
     private String password;
 
     @Bean
-    public RedisConnectionFactory redisConnectionFactory() {
+    // Lettuce는 ReactiveRedisConnectionFactory의 구현체 중 일부
+    public ReactiveRedisConnectionFactory connectionFactory() {
         RedisStandaloneConfiguration redisConfiguration = new RedisStandaloneConfiguration();
         redisConfiguration.setHostName(host);
         redisConfiguration.setPort(port);
@@ -49,16 +53,16 @@ public class RedisConfig {
     }
 
     @Bean(name = "userInfoTemplate")
-    public RedisTemplate<String, UserInfoDTO> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
-        RedisTemplate<String, UserInfoDTO> redisTemplate = new RedisTemplate<>();
-        redisTemplate.setConnectionFactory(redisConnectionFactory);
+    public ReactiveRedisTemplate<String, UserInfoDTO> reactiveRedisTemplate(ReactiveRedisConnectionFactory connectionFactory) {
+        Jackson2JsonRedisSerializer<UserInfoDTO> serializer = new Jackson2JsonRedisSerializer<>(UserInfoDTO.class);
+        RedisSerializationContext.RedisSerializationContextBuilder<String, UserInfoDTO> builder
+                = RedisSerializationContext.newSerializationContext(new StringRedisSerializer());
 
-        redisTemplate.setKeySerializer(new StringRedisSerializer());
-        redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(UserInfoDTO.class));
+        RedisSerializationContext<String, UserInfoDTO> context = builder.value(serializer)
+                .hashValue(serializer)
+                .hashKey(serializer)
+                .build();
 
-        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
-        redisTemplate.setHashValueSerializer(new Jackson2JsonRedisSerializer<>(UserInfoDTO.class));
-
-        return redisTemplate;
+        return new ReactiveRedisTemplate<>(connectionFactory, context);
     }
 }

--- a/src/main/java/com/example/chatgateway/global/config/RedisConfig.java
+++ b/src/main/java/com/example/chatgateway/global/config/RedisConfig.java
@@ -1,0 +1,64 @@
+package com.example.chatgateway.global.config;
+
+import com.example.chatgateway.domain.dto.UserInfoDTO;
+import io.lettuce.core.ClientOptions;
+import io.lettuce.core.SocketOptions;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+    @Value("${spring.data.redis.port}")
+    private int port;
+    @Value("${spring.data.redis.password}")
+    private String password;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration redisConfiguration = new RedisStandaloneConfiguration();
+        redisConfiguration.setHostName(host);
+        redisConfiguration.setPort(port);
+        redisConfiguration.setPassword(password);
+        redisConfiguration.setDatabase(0);
+
+        final SocketOptions socketoptions = SocketOptions.builder().connectTimeout(Duration.ofSeconds(10)).build();
+        final ClientOptions clientoptions = ClientOptions.builder().socketOptions(socketoptions).build();
+
+        LettuceClientConfiguration lettuceClientConfiguration = LettuceClientConfiguration.builder()
+                .clientOptions(clientoptions)
+                .commandTimeout(Duration.ofMinutes(1))
+                .shutdownTimeout(Duration.ZERO)
+                .build();
+
+        return new LettuceConnectionFactory(redisConfiguration, lettuceClientConfiguration);
+    }
+
+    @Bean(name = "userInfoTemplate")
+    public RedisTemplate<String, UserInfoDTO> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, UserInfoDTO> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory);
+
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(UserInfoDTO.class));
+
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashValueSerializer(new Jackson2JsonRedisSerializer<>(UserInfoDTO.class));
+
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/example/chatgateway/global/config/RoutesConfig.java
+++ b/src/main/java/com/example/chatgateway/global/config/RoutesConfig.java
@@ -25,6 +25,9 @@ public class RoutesConfig {
     @Value("${uri.ws}")
     private String ws;
 
+    @Value("${uri.participant}")
+    private String participant;
+
     private final AuthFilter authFilter;
 
     @Bean
@@ -42,6 +45,9 @@ public class RoutesConfig {
                         .uri(message))
 //                .route("ws", r -> r.path("/stomp/chat/**")
 //                        .uri(ws))
+                .route("participant", r -> r.path("/api/participants/**")
+                        .filters(f -> f.filter(authFilter))
+                        .uri(participant))
                 .build();
     }
 

--- a/src/main/java/com/example/chatgateway/global/filter/AuthFilter.java
+++ b/src/main/java/com/example/chatgateway/global/filter/AuthFilter.java
@@ -54,13 +54,13 @@ public class AuthFilter implements GatewayFilter {
             return chain.filter(exchange);
         }
 
-        String token;
+        String token= extractTokenFromCookies(exchange.getRequest());;
 
-        if (path.startsWith("/open-chats/access")) {
-            token = exchange.getRequest().getHeaders().getFirst("Authorization");
-        } else {
-            token = extractTokenFromCookies(exchange.getRequest());
-        }
+//        if (path.startsWith("/open-chats/access")) {
+//            token = exchange.getRequest().getHeaders().getFirst("Authorization");
+//        } else {
+//            token = extractTokenFromCookies(exchange.getRequest());
+//        }
 
         log.info("확인된 토큰: {}", token);
         if (token == null) {

--- a/src/main/java/com/example/chatgateway/global/filter/AuthFilter.java
+++ b/src/main/java/com/example/chatgateway/global/filter/AuthFilter.java
@@ -57,7 +57,7 @@ public class AuthFilter implements GatewayFilter {
             return Mono.error(new ResponseStatusException(HttpStatus.UNAUTHORIZED, "No access token found"));
         }
 
-        UUID id = UUID.randomUUID();
+        String id = token;
         log.info("추출된 토큰: {} // 아이디: {}", token, id);
 
         TokenDTO tokenDTO = new TokenDTO(id, token);

--- a/src/main/java/com/example/chatgateway/global/filter/AuthFilter.java
+++ b/src/main/java/com/example/chatgateway/global/filter/AuthFilter.java
@@ -9,7 +9,6 @@ import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.http.HttpCookie;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.server.reactive.ServerHttpRequest;
@@ -45,7 +44,7 @@ public class AuthFilter implements GatewayFilter {
     @Override
     public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
         String uri = exchange.getRequest().getURI().toString();
-        log.info("요청이 들어온 경로: {}", uri);
+        log.info("☆☪☆☪☆☪☆☪☆☪☆☪☆☪☆☪☆☪☆☪ 요청이 들어온 경로: {} ☆☪☆☪☆☪☆☪☆☪☆☪☆☪☆☪☆☪☆☪☆☪", uri);
         String path = exchange.getRequest().getURI().getPath();
 
         log.info("응답 초기 헤더 확인: {}", exchange.getResponse().getHeaders()); // 여기서는 문제 없음
@@ -55,7 +54,15 @@ public class AuthFilter implements GatewayFilter {
             return chain.filter(exchange);
         }
 
-        String token = extractTokenFromCookies(exchange.getRequest());
+        String token;
+
+        if (path.startsWith("/open-chats/access")) {
+            token = exchange.getRequest().getHeaders().getFirst("Authorization");
+        } else {
+            token = extractTokenFromCookies(exchange.getRequest());
+        }
+
+        log.info("확인된 토큰: {}", token);
         if (token == null) {
             return Mono.error(new ResponseStatusException(HttpStatus.UNAUTHORIZED, "No access token found"));
         }


### PR DESCRIPTION
## 기존 모델의 문제점 및 수정

- 다른 인스턴스와 다르게 인증 인스턴스는 실시간성 및 호출의 빈번함 때문에 라우팅이 아닌 카프카를 기반으로 송수신
- 초기에는 카프카를 통신 수단으로 생각하면서 인스턴스 간의 송수신을 맡을 수 있는 것으로 착오

### 기존 모델의 문제점

- API Gateway와 Auth 인스턴스 간에 카프카 송수신 형식으로 구축하였음
- 자연스럽게 인증 여부 및 그 결과를 API Gateway에 다시 넘겨줘야 했기에, 요청 - 응답 모델이 구축됨


```java

return kafkaProducerTemplate.send(topic, id.toString(), tokenDTO)
            .then(Mono.defer(() -> {
                // 인증 응답 대기
                return kafkaReceiver
                        .receive()
                        /**
                         * 필터 쪽 여기가 문제인 거 같은데 왜 그런질 모르겠네... 흠... 다시 해 보자...
                         */
                        .filter(record -> record.key().equals(id.toString()))
                        .next()
                        .map(ConsumerRecord::value)
                        .flatMap(userInfoDTO -> {
                            // 쿠키 업데이트
                            updateTokenCookieIfNeeded(exchange, token, userInfoDTO.getToken());
    
                            // 인증 결과를 요청 헤더에 추가
                            ServerHttpRequest modifiedRequest = exchange.getRequest()
                                    .mutate()
                                    .header("email", userInfoDTO.getEmail())
                                    .header("role", userInfoDTO.getRole())
                                    .build();
    
                            log.info("응답 이메일 및 권한: {}. {}", userInfoDTO.getEmail(), userInfoDTO.getRole());
                            log.info("인증 이후의 응답 헤더 확인: {}", exchange.getResponse().getHeaders());
    
                            // 수정된 요청으로 다음 단계로 넘기기
                            return chain.filter(exchange.mutate().request(modifiedRequest).build());
                        })
                        .timeout(Duration.ofSeconds(10))  // 타임아웃 설정
                        .onErrorResume(e -> {
                            // 오류 처리
                            return Mono.error(new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Error during authentication", e));
                        });
            }));
```

- 이렇게 됨으로써 kafka의 비동기 스트리밍 기반 분산 메세징 툴이라는 취지를 정면으로 위배
- 자연스럽게 동기적 처리가 됨으로써 대용량 트래픽 요청에 대하여 에러 반환

### 카프카는 순수히 전파, API Gateway의 조회 시도 로직으로 선회

```java
return kafkaProducerTemplate.send(topic, tokenDTO)
        .flatMap(result -> {
            // Kafka에 메시지 전송 후 Redis에서 결과를 비동기적으로 조회
            return checkRedisForUserInfo(id)
                    .flatMap(userInfoDTO -> {
                        ServerHttpRequest modifiedRequest = exchange.getRequest()
                                .mutate()
                                .header("email", userInfoDTO.getEmail())
                                .header("role", userInfoDTO.getRole())
                                .header("id", userInfoDTO.getId())
                                .build();

                        updateTokenCookieIfNeeded(exchange, token, userInfoDTO.getToken());
                        return chain.filter(exchange.mutate().request(modifiedRequest).build());
                    });
        })
        .onErrorResume(e -> {
            // Kafka 전송 오류 처리
            log.error("Kafka 전송 오류: {}", e.getMessage());
            return Mono.error(
                    new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "카프카 전송 로직 에러 발생"));
        });
```

- 인증 정보를 캐시로써 활용하기 위한 redis를 끌어와서 직접 인증 정보의 업데이트를 API Gateway가 조회하는 방식으로 처리
- reactor 패턴 최대한 활용

### 고려할 점

- 동기적인 gRPC 또는 REST API 사용 고려
- Redis에서 인증 결과를 조회할 때 데이터 손실에 대한 복구 전략이 필요
- Kafka 전송 지연 시 응답 타임아웃 정책
- 토큰 갱신 로직의 명확화 및 보안 강화




  