### PR TITLE
[Refactor] 웹소켓 서버 전환에 따른 CORS 관리 처리

### DIFF
--- a/src/main/java/com/example/chatgateway/global/config/RoutesConfig.java
+++ b/src/main/java/com/example/chatgateway/global/config/RoutesConfig.java
@@ -45,7 +45,7 @@ public class RoutesConfig {
                         .uri(message))
 //                .route("ws", r -> r.path("/stomp/chat/**")
 //                        .uri(ws))
-                .route("participant", r -> r.path("/api/participants/**")
+                .route("participant", r -> r.path("/stomp/participant/**")
                         .filters(f -> f.filter(authFilter))
                         .uri(participant))
                 .build();


### PR DESCRIPTION
## 웹소켓 서버의 CORS 정책 관리
- 현재 http 프로토콜에 대해서는 API Gateway에서 직접 CORS 관리
```yml
# API Gateway yml

  cloud:
    gateway:
      default-filters:
        - DedupeResponseHeader=Access-Control-Allow-Origin Access-Control-Allow-Credentials
      routes:
        - id: user
          uri: ${uri.user}
          predicates:
            - Path=/api/users/**
          metadata:
            cors:
              allowedOrigins: ${client.url}
              allowCredentials: true
              // ...

```
- 웹소켓 인스턴스는 인스턴스에서 직접 CORS 관리
- 아직 이유를 확실히 파악하지는 못했지만, API Gateway에서의 CORS 관리는 http만 가능..?
- 그렇다고 인스턴스에서 웹소켓 CORS 관련 설정만 하면 중복 적용 문제 발생...?
- 하여, 웹소켓 인스턴스는 직접 CORS 관리